### PR TITLE
Define extensions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ ReduxGTM will emit `some-gtm-custom-event` to Google Tag Manager.
  - [How to do mini surveys](docs/examples/example3.md)
 
 ## API
- - [createMiddleware](docs/create-middleware.md)([eventDefinitionsMap](docs/event-definitions-map.md), [[options]](docs/options.md))
- - [createMetaReducer](docs/create-meta-reducer.md)([eventDefinitionsMap](docs/event-definitions-map.md), [[options]](docs/options.md))
+ - [createMiddleware](docs/create-middleware.md)([eventDefinitionsMap](docs/event-definitions-map.md), [[extensions]](docs/extensions.md))
+ - [createMetaReducer](docs/create-meta-reducer.md)([eventDefinitionsMap](docs/event-definitions-map.md), [[extensions]](docs/extensions.md))
  - [EventHelpers](docs/event-helpers/event-helpers.md)
    - [createGAevent](docs/event-helpers/create-ga-event.md)
    - [createGApageview](docs/event-helpers/create-ga-pageview.md)

--- a/docs/event-definition.md
+++ b/docs/event-definition.md
@@ -21,7 +21,7 @@ Use this property to specify the name of the event you want to emit
 for the associated action. If not provided, the event name defaults to
 the action type.
 
-#### `function` eventFields *(optional)*
+#### `function` eventFields(prevState, action) *(optional)*
 Attach a function to this property to define any variables you would
 like to emit with the event. Any function assigned to this property
 will receive the state of the application (before the action), and the

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,13 +1,18 @@
-# options
+# extensions
+
+There are three types of extensions supported by ReduxGTM:
  - [customDataLayer](#customdatalayer)
- - [connectivitySelector](#connectivityselector)
  - [offlineStorage](#offlinestorage)
+ - [logger](#logger)
 
 ## customDataLayer
+An `Object`that ReduxGTM will push events to instead of the `window.dataLayer`.
 
-An `object` with a `push` method for adding events to a custom data
-layer. The push method must accept a plain event object as its first
-argument.
+### Properties
+
+#### `function` push
+ReduxGTM will call this function with each created event. The function
+should accept a plain event object as its first argument.
 
 ### Example
 
@@ -35,14 +40,18 @@ const gtmMiddleware = createMiddlware(eventDefinitionsMap, { customDataLayer });
 const store = createStore(combinedReducer, applyMiddleware(gtmMiddleware));
 ```
 
-## connectivitySelector
-A selector function that accepts the redux state, and returns a
-connectivity boolean. ReduxGTM uses this connectivity boolean to
-determine whether or not your app is offline. ReduxGTM expects the
-connectivity boolean to be `true` when your app is online, and `false`
-when your app is offline.
-
 ## offlineStorage
-A constructor for an offline storage abstraction (e.g. IndexDB and
-AsyncStorage/ReactNative). ReduxGTM will store events here when
-offline, and retrieve stored events from here when back online.
+An `Object` that ReduxGTM will use to determine whether or not your
+app is offline.
+
+### Properties
+
+#### `function` saveEvents(events)
+#### `function` purgeEvents()
+#### `function` isConnected(state)
+
+## logger
+
+### Properties
+
+#### `function` log(event, action, state)

--- a/src/create-meta-reducer.js
+++ b/src/create-meta-reducer.js
@@ -2,19 +2,19 @@ const createEvents = require('./create-events');
 const getDataLayer = require('./get-data-layer');
 const registerEvents = require('./register-events');
 
-const createMetaReducer = (eventDefinitionsMap, options = {}) => reducer => (prevState, action) => {
+const createMetaReducer = (eventDefinitionsMap, extensions = {}) => reducer => (prevState, action) => {
   if (!eventDefinitionsMap[action.type]) {
     return reducer(prevState, action);
   }
 
-  const dataLayer = getDataLayer(window, options.customDataLayer);
+  const dataLayer = getDataLayer(window, extensions.customDataLayer);
 
   if (dataLayer === undefined) {
     return reducer(prevState, action);
   }
 
   const events = createEvents(eventDefinitionsMap[action.type], prevState, action);
-  registerEvents(events, dataLayer, prevState, options);
+  registerEvents(events, dataLayer, prevState, extensions, action);
 
   return reducer(prevState, action);
 };

--- a/src/create-meta-reducer.js
+++ b/src/create-meta-reducer.js
@@ -2,21 +2,25 @@ const createEvents = require('./create-events');
 const getDataLayer = require('./get-data-layer');
 const registerEvents = require('./register-events');
 
-const createMetaReducer = (eventDefinitionsMap, extensions = {}) => reducer => (prevState, action) => {
-  if (!eventDefinitionsMap[action.type]) {
-    return reducer(prevState, action);
-  }
+function createMetaReducer(eventDefinitionsMap, extensions = {}) {
+  return function (reducer) {
+    return function (prevState, action) {
+      if (!eventDefinitionsMap[action.type]) {
+        return reducer(prevState, action);
+      }
 
-  const dataLayer = getDataLayer(window, extensions.customDataLayer);
+      const dataLayer = getDataLayer(window, extensions.customDataLayer);
 
-  if (dataLayer === undefined) {
-    return reducer(prevState, action);
-  }
+      if (dataLayer === undefined) {
+        return reducer(prevState, action);
+      }
 
-  const events = createEvents(eventDefinitionsMap[action.type], prevState, action);
-  registerEvents(events, dataLayer, prevState, extensions, action);
+      const events = createEvents(eventDefinitionsMap[action.type], prevState, action);
+      registerEvents(events, dataLayer, prevState, extensions, action);
 
-  return reducer(prevState, action);
-};
+      return reducer(prevState, action);
+    };
+  };
+}
 
 module.exports = createMetaReducer;

--- a/src/create-middleware.js
+++ b/src/create-middleware.js
@@ -2,12 +2,12 @@ const createEvents = require('./create-events');
 const registerEvents = require('./register-events');
 const getDataLayer = require('./get-data-layer');
 
-const createMiddleware = (eventDefinitionsMap, options = {}) => store => next => (action) => {
+const createMiddleware = (eventDefinitionsMap, extensions = {}) => store => next => (action) => {
   if (!eventDefinitionsMap[action.type]) {
     return next(action);
   }
 
-  const dataLayer = getDataLayer(window, options.customDataLayer);
+  const dataLayer = getDataLayer(window, extensions.customDataLayer);
 
   if (dataLayer === undefined) {
     return next(action);
@@ -16,7 +16,7 @@ const createMiddleware = (eventDefinitionsMap, options = {}) => store => next =>
   const prevState = store.getState();
 
   const events = createEvents(eventDefinitionsMap[action.type], prevState, action);
-  registerEvents(events, dataLayer, prevState, options);
+  registerEvents(events, dataLayer, prevState, extensions, action);
 
   return next(action);
 };

--- a/src/register-events.js
+++ b/src/register-events.js
@@ -1,23 +1,39 @@
-function registerEvents(events, dataLayer, state, options) {
+function registerEvents(events, dataLayer, state, extensions, action) {
   const {
-    connectivitySelector,
+    logger,
     offlineStorage,
-  } = options;
+  } = extensions;
+
+  const logEvents = (...args) => {
+    if (logger !== undefined && typeof logger.log === 'function') {
+      logger.log(...args);
+    }
+  };
 
   const pushEventsToDataLayer = (eventsToPush) => {
     eventsToPush.forEach(eventToPush => dataLayer.push(eventToPush));
+    return eventsToPush;
   };
 
-  if (typeof connectivitySelector === 'function') {
-    const isConnected = connectivitySelector(state);
+  if (offlineStorage !== undefined) {
+    const isConnected = offlineStorage.isConnected(state);
     if (!isConnected) {
-      offlineStorage.saveEvents(events);
+      offlineStorage.saveEvents(events)
+                    .then(savedEvents => {
+                      logEvents(savedEvents, action, state, true, false);
+                    });
     } else {
       pushEventsToDataLayer(events);
-      offlineStorage.purgeEvents().then(pushEventsToDataLayer);
+      logEvents(events, action, state);
+      offlineStorage.purgeEvents()
+                    .then(pushEventsToDataLayer)
+                    .then(oldEvents => {
+                      logEvents(oldEvents, action, state, false, true);
+                    });
     }
   } else {
     pushEventsToDataLayer(events);
+    logEvents(events, action, state);
   }
 }
 

--- a/src/register-events.js
+++ b/src/register-events.js
@@ -19,7 +19,7 @@ function registerEvents(events, dataLayer, state, extensions, action) {
     const isConnected = offlineStorage.isConnected(state);
     if (!isConnected) {
       offlineStorage.saveEvents(events)
-                    .then(savedEvents => {
+                    .then((savedEvents) => {
                       logEvents(savedEvents, action, state, true, false);
                     });
     } else {
@@ -27,7 +27,7 @@ function registerEvents(events, dataLayer, state, extensions, action) {
       logEvents(events, action, state);
       offlineStorage.purgeEvents()
                     .then(pushEventsToDataLayer)
-                    .then(oldEvents => {
+                    .then((oldEvents) => {
                       logEvents(oldEvents, action, state, false, true);
                     });
     }

--- a/test/meta-reducer.js
+++ b/test/meta-reducer.js
@@ -7,19 +7,6 @@ describe('createMetaReducer(eventDefinitionsMap, [options])', () => {
     window.dataLayer = undefined;
   });
 
-  describe('When a window.dataLayer variable does not exist', () => {
-    it('creates a window.dataLayer variable and sets it to an empty array', () => {
-      const reducer = state => state;
-      const eventDefinitionsMap = { SOME_ACTION: {} };
-      const gtmMetaReducer = createMetaReducer(eventDefinitionsMap);
-      const store = createStore(gtmMetaReducer(reducer));
-
-      expect(window.dataLayer).toBeUndefined();
-      store.dispatch({ type: 'SOME_ACTION' });
-      expect(window.dataLayer).toBeDefined();
-    });
-  });
-
   describe('When a valid event definitions map is provided ', () => {
     it('creates the events and pushes them to the data layer', () => {
       const initialState = {
@@ -59,81 +46,11 @@ describe('createMetaReducer(eventDefinitionsMap, [options])', () => {
     });
   });
 
-  describe("When an event does not match it's schema", () => {
-    it('does not push the event to the data layer', () => {
-      const reducer = (state = {}) => state;
-      const eventDefinitionsMap = {
-        LOCATION_CHANGED: {
-          eventName: 'page-view',
-          eventFields() {
-            return {};
-          },
-          eventSchema: {
-            event: () => true,
-            route: () => false,
-          },
-        },
-      };
-      const gtmMetaReducer = createMetaReducer(eventDefinitionsMap);
-      const store = createStore(gtmMetaReducer(reducer));
-
-      store.dispatch({ type: 'LOCATION_CHANGED' });
-      expect(window.dataLayer).toEqual([]);
-    });
-  });
-
-  describe('When a custom data layer is provided', () => {
-    it('pushes events to the custom data layer', () => {
-      const eventDefinitionsMap = {
-        FORM_FILL_ENDED: { eventName: 'user-form-input' },
-      };
-      const customDataLayer = { push: jest.fn() };
-      const gtmMetaReducer = createMetaReducer(eventDefinitionsMap, { customDataLayer });
-      const reducer = state => state;
-      const store = createStore(gtmMetaReducer(reducer));
-
-      const expected = { event: 'user-form-input' };
-      store.dispatch({ type: 'FORM_FILL_ENDED' });
-      expect(customDataLayer.push).toHaveBeenCalledWith(expected);
-    });
-  });
-
-  describe('When an array of event definitions is provided for a given action', () => {
-    it('creates an event for each definition and pushes it to the data layer', () => {
-      const eventDefinitionsMap = {
-        SOME_REDUX_ACTION: [
-          { eventName: 'event1' },
-          { eventName: 'event2' },
-          { eventName: 'event3' },
-        ],
-      };
-      const gtmMetaReducer = createMetaReducer(eventDefinitionsMap);
-      const reducer = state => state;
-      const store = createStore(gtmMetaReducer(reducer));
-
-      const expected = [
-        { event: 'event1' },
-        { event: 'event2' },
-        { event: 'event3' },
-      ];
-      store.dispatch({ type: 'SOME_REDUX_ACTION' });
-      const actual = window.dataLayer;
-      expect(actual).toEqual(expected);
-    });
-  });
-
   describe('When an action does not have an associated event definition', () => {
     const gtmMetaReducer = createMetaReducer({});
     const reducer = state => state;
 
-    it('does not create a new data layer', () => {
-      const store = createStore(gtmMetaReducer(reducer));
-      store.dispatch({ type: 'SOME_REDUX_ACTION' });
-
-      const actual = window.dataLayer;
-      expect(actual).toBeUndefined();
-    });
-    it('does not mutate an existing data layer', () => {
+    it('does not push any events to the data layer', () => {
       const store = createStore(gtmMetaReducer(reducer));
       window.dataLayer = [{ event: 'some-event' }];
       store.dispatch({ type: 'SOME_REDUX_ACTION' });
@@ -141,75 +58,6 @@ describe('createMetaReducer(eventDefinitionsMap, [options])', () => {
       const expected = [{ event: 'some-event' }]; // no change
       const actual = window.dataLayer;
       expect(actual).toEqual(expected);
-    });
-  });
-
-  describe('When a connectivitySelector is provided and the app is offline', () => {
-    const options = {
-      offlineStorage: { saveEvents: jest.fn() },
-      connectivitySelector: () => false,
-    };
-    const reducer = state => state;
-    const eventDefinitionsMap = { SOME_ACTION: {} };
-    const gtmMetaReducer = createMetaReducer(eventDefinitionsMap, options);
-
-    it('saves events to the provided offlineStorage option', () => {
-      const store = createStore(gtmMetaReducer(reducer));
-      store.dispatch({ type: 'SOME_ACTION' });
-
-      expect(options.offlineStorage.saveEvents).toHaveBeenCalledWith([{ event: 'SOME_ACTION' }]);
-    });
-
-    it('does not push events to the data layer', () => {
-      const store = createStore(gtmMetaReducer(reducer));
-      store.dispatch({ type: 'SOME_ACTION' });
-
-      const expected = [];
-      const actual = window.dataLayer;
-      expect(actual).toEqual(expected);
-    });
-  });
-
-  describe('When a connectivitySelector is provided and the app is online', () => {
-    it('purges events from offlineStorage', () => {
-      const options = {
-        offlineStorage: { purgeEvents: jest.fn(() => Promise.resolve([])) },
-        connectivitySelector: () => true,
-      };
-      const reducer = state => state;
-      const eventDefinitionsMap = { SOME_ACTION: {} };
-      const gtmMetaReducer = createMetaReducer(eventDefinitionsMap, options);
-      const store = createStore(gtmMetaReducer(reducer));
-
-      store.dispatch({ type: 'SOME_ACTION' });
-      expect(options.offlineStorage.purgeEvents).toHaveBeenCalled();
-    });
-
-    it('saves any events from offlineStorage to the data layer', () => {
-      // This isn't the greatest integration test for createMiddleware.
-      // The issue is that offline events are pushed to the data layer
-      // asynchronously. So I ended up attaching the assertion to the
-      // window.dataLayer.push stub. It's gross, I know.
-      const expected = { event: 'some-old-event' };
-      window.dataLayer = {
-        push: (event) => {
-          if (event.event !== 'SOME_ACTION') {
-            expect(event).toEqual(expected);
-          }
-        },
-      };
-      const options = {
-        offlineStorage: {
-          purgeEvents: () => Promise.resolve([{ event: 'some-old-event' }]),
-        },
-        connectivitySelector: () => true,
-      };
-      const reducer = state => state;
-      const eventDefinitionsMap = { SOME_ACTION: {} };
-      const gtmMetaReducer = createMetaReducer(eventDefinitionsMap, options);
-      const store = createStore(gtmMetaReducer(reducer));
-
-      store.dispatch({ type: 'SOME_ACTION' });
     });
   });
 });

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -7,20 +7,7 @@ describe('createMiddleware(eventDefinitionsMap, [extensions])', () => {
     window.dataLayer = undefined;
   });
 
-  describe('When a window.dataLayer variable does not exist', () => {
-    it('creates a window.dataLayer variable and sets it to an empty array', () => {
-      const reducer = state => state;
-      const eventDefinitionsMap = { SOME_ACTION: {} };
-      const gtmMiddleware = createMiddleware(eventDefinitionsMap);
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-
-      expect(window.dataLayer).toBeUndefined();
-      store.dispatch({ type: 'SOME_ACTION' });
-      expect(window.dataLayer).toBeDefined();
-    });
-  });
-
-  describe('When a valid event definitions map is provided ', () => {
+  describe('When an action with an event definition is dispatched', () => {
     it('creates the events and pushes them to the data layer', () => {
       const initialState = {
         formFillStartTime: 1,
@@ -59,81 +46,11 @@ describe('createMiddleware(eventDefinitionsMap, [extensions])', () => {
     });
   });
 
-  describe("When an event does not match it's schema", () => {
-    it('does not push the event to the data layer', () => {
-      const reducer = (state = {}) => state;
-      const eventDefinitionsMap = {
-        LOCATION_CHANGED: {
-          eventName: 'page-view',
-          eventFields() {
-            return {};
-          },
-          eventSchema: {
-            event: () => true,
-            route: () => false,
-          },
-        },
-      };
-      const gtmMiddleware = createMiddleware(eventDefinitionsMap);
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-
-      store.dispatch({ type: 'LOCATION_CHANGED' });
-      expect(window.dataLayer).toEqual([]);
-    });
-  });
-
-  describe('When a custom data layer is provided', () => {
-    it('pushes events to the custom data layer', () => {
-      const eventDefinitionsMap = {
-        FORM_FILL_ENDED: { eventName: 'user-form-input' },
-      };
-      const customDataLayer = { push: jest.fn() };
-      const gtmMiddleware = createMiddleware(eventDefinitionsMap, { customDataLayer });
-      const reducer = state => state;
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-
-      const expected = { event: 'user-form-input' };
-      store.dispatch({ type: 'FORM_FILL_ENDED' });
-      expect(customDataLayer.push).toHaveBeenCalledWith(expected);
-    });
-  });
-
-  describe('When an array of event definitions is provided for a given action', () => {
-    it('creates an event for each definition and pushes it to the data layer', () => {
-      const eventDefinitionsMap = {
-        SOME_REDUX_ACTION: [
-          { eventName: 'event1' },
-          { eventName: 'event2' },
-          { eventName: 'event3' },
-        ],
-      };
-      const gtmMiddleware = createMiddleware(eventDefinitionsMap);
-      const reducer = state => state;
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-
-      const expected = [
-        { event: 'event1' },
-        { event: 'event2' },
-        { event: 'event3' },
-      ];
-      store.dispatch({ type: 'SOME_REDUX_ACTION' });
-      const actual = window.dataLayer;
-      expect(actual).toEqual(expected);
-    });
-  });
-
   describe('When an action does not have an associated event definition', () => {
     const gtmMiddleware = createMiddleware({});
     const reducer = state => state;
 
-    it('does not create a new data layer', () => {
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-      store.dispatch({ type: 'SOME_REDUX_ACTION' });
-
-      const actual = window.dataLayer;
-      expect(actual).toBeUndefined();
-    });
-    it('does not mutate an existing data layer', () => {
+    it('does not push any events to the data layer', () => {
       const store = createStore(reducer, applyMiddleware(gtmMiddleware));
       window.dataLayer = [{ event: 'some-event' }];
       store.dispatch({ type: 'SOME_REDUX_ACTION' });
@@ -141,79 +58,6 @@ describe('createMiddleware(eventDefinitionsMap, [extensions])', () => {
       const expected = [{ event: 'some-event' }]; // no change
       const actual = window.dataLayer;
       expect(actual).toEqual(expected);
-    });
-  });
-
-  describe('When an offlineStorage extension is provided and the app is offline', () => {
-    const extensions = {
-      offlineStorage: {
-        saveEvents: jest.fn(),
-        isConnected: () => false,
-      },
-    };
-    const reducer = state => state;
-    const eventDefinitionsMap = { SOME_ACTION: {} };
-    const gtmMiddleware = createMiddleware(eventDefinitionsMap, extensions);
-
-    it('saves events to the provided offlineStorage option', () => {
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-      store.dispatch({ type: 'SOME_ACTION' });
-
-      expect(extensions.offlineStorage.saveEvents).toHaveBeenCalledWith([{ event: 'SOME_ACTION' }]);
-    });
-
-    it('does not push events to the data layer', () => {
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-      store.dispatch({ type: 'SOME_ACTION' });
-
-      const expected = [];
-      const actual = window.dataLayer;
-      expect(actual).toEqual(expected);
-    });
-  });
-
-  describe('When an offlineStorage extension is provided and the app is offline', () => {
-    it('purges events from offlineStorage', () => {
-      const extensions = {
-        offlineStorage: {
-          purgeEvents: jest.fn(() => Promise.resolve([])),
-          isConnected: () => true,
-        },
-      };
-      const reducer = state => state;
-      const eventDefinitionsMap = { SOME_ACTION: {} };
-      const gtmMiddleware = createMiddleware(eventDefinitionsMap, extensions);
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-
-      store.dispatch({ type: 'SOME_ACTION' });
-      expect(extensions.offlineStorage.purgeEvents).toHaveBeenCalled();
-    });
-
-    it('saves any events from offlineStorage to the data layer', () => {
-      // This isn't the greatest integration test for createMiddleware.
-      // The issue is that offline events are pushed to the data layer
-      // asynchronously. So I ended up attaching the assertion to the
-      // window.dataLayer.push stub. It's gross, I know.
-      const expected = { event: 'some-old-event' };
-      window.dataLayer = {
-        push: (event) => {
-          if (event.event !== 'SOME_ACTION') {
-            expect(event).toEqual(expected);
-          }
-        },
-      };
-      const extensions = {
-        offlineStorage: {
-          purgeEvents: () => Promise.resolve([{ event: 'some-old-event' }]),
-          isConnected: () => true,
-        },
-      };
-      const reducer = state => state;
-      const eventDefinitionsMap = { SOME_ACTION: {} };
-      const gtmMiddleware = createMiddleware(eventDefinitionsMap, extensions);
-      const store = createStore(reducer, applyMiddleware(gtmMiddleware));
-
-      store.dispatch({ type: 'SOME_ACTION' });
     });
   });
 });

--- a/test/register-events.js
+++ b/test/register-events.js
@@ -15,7 +15,6 @@ describe('registerEvents(events, dataLayer, state, extensions, action)', () => {
 
   describe('When provided with an offline storage extension', () => {
     describe('When the app is offline', () => {
-      const state = { isConnected: false };
       const dataLayer = { push: jest.fn() };
       const events = [{ event: 'some-event' }, { event: 'some-other-event' }];
       const extensions = {
@@ -24,6 +23,7 @@ describe('registerEvents(events, dataLayer, state, extensions, action)', () => {
           isConnected: state => state.isConnected,
         },
       };
+      const state = { isConnected: false };
       registerEvents(events, dataLayer, state, extensions);
 
       it('pushes events to offline storage', () => {
@@ -99,7 +99,7 @@ describe('registerEvents(events, dataLayer, state, extensions, action)', () => {
       const events = [{ event: 'some-event' }];
       const action = { type: 'SOME_ACTION' };
       const state = {};
-      const dataLayer = { push(){} };
+      const dataLayer = { push() {} };
       registerEvents(events, dataLayer, state, extensions, action);
 
       expect(extensions.logger.log).toHaveBeenCalledWith(events, action, state);

--- a/test/register-events.js
+++ b/test/register-events.js
@@ -1,86 +1,132 @@
 const registerEvents = require('../src/register-events');
 
-describe('registerEvents(events, dataLayer, state, options)', () => {
-  describe('When a connectivity selector is not provided', () => {
+describe('registerEvents(events, dataLayer, state, extensions, action)', () => {
+  describe('When given an array of events, and a data layer', () => {
     const events = [{ event: 'some-event' }];
     const dataLayer = { push: jest.fn() };
     const state = {};
-    const options = {};
+    const extensions = {};
 
     it('pushes events to the data layer', () => {
-      registerEvents(events, dataLayer, state, options);
+      registerEvents(events, dataLayer, state, extensions);
       expect(dataLayer.push).toHaveBeenCalledWith({ event: 'some-event' });
     });
   });
 
-  describe('When a connectivity selector is provided, and the app is offline', () => {
-    const events = [{ event: 'some-event' }, { event: 'some-other-event' }];
-    const dataLayer = { push: jest.fn() };
-    const options = {
-      connectivitySelector: state => state.isConnected,
-      offlineStorage: { saveEvents: jest.fn() },
-    };
-    const state = { isConnected: false };
-
-    registerEvents(events, dataLayer, state, options);
-
-    it('pushes events to offline storage', () => {
-      expect(options.offlineStorage.saveEvents).toHaveBeenCalledWith(events);
-    });
-    it('does not push events to the data layer', () => {
-      expect(dataLayer.push).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('When a connectivity selector is provided, and the app is online', () => {
-    it('purges events from offline storage', () => {
-      const events = [];
-      const dataLayer = { push: () => {} };
-      const options = {
-        connectivitySelector: state => state.isConnected,
-        offlineStorage: { purgeEvents: jest.fn(() => Promise.resolve()) },
-      };
-      const state = { isConnected: true };
-
-      registerEvents(events, dataLayer, state, options);
-      expect(options.offlineStorage.purgeEvents).toHaveBeenCalled();
-    });
-    it('pushes the new events to the data layer, synchronously', () => {
-      const events = [{ event: 'some-event' }];
+  describe('When provided with an offline storage extension', () => {
+    describe('When the app is offline', () => {
+      const state = { isConnected: false };
       const dataLayer = { push: jest.fn() };
-      const options = {
-        connectivitySelector: state => state.isConnected,
-        offlineStorage: { purgeEvents: () => Promise.resolve() },
-      };
-      const state = { isConnected: true };
-
-      registerEvents(events, dataLayer, state, options);
-      expect(dataLayer.push).toHaveBeenCalledWith({ event: 'some-event' });
-    });
-    it('purges events from offline storage and pushes them to the data layer', () => {
-      const events = [];
-      const oldEvents = [{ event: 'some-event' }];
-      const options = {
-        connectivitySelector: state => state.isConnected,
+      const events = [{ event: 'some-event' }, { event: 'some-other-event' }];
+      const extensions = {
         offlineStorage: {
-          purgeEvents: () => Promise.resolve(oldEvents),
+          saveEvents: jest.fn(() => Promise.resolve()),
+          isConnected: state => state.isConnected,
         },
       };
-      const state = { isConnected: true };
+      registerEvents(events, dataLayer, state, extensions);
 
-      // dataLayer.push will first be called with the new events.
-      // It should be called a second time with the events that were
-      // purged from offline storage.
-      let numTimesCalled = 0;
-      const dataLayer = {
-        push() {
-          numTimesCalled += 1;
-          if (numTimesCalled === 2) {
-            expect(events).toEqual({ event: 'some-event' });
-          }
-        },
+      it('pushes events to offline storage', () => {
+        expect(extensions.offlineStorage.saveEvents).toHaveBeenCalledWith(events);
+      });
+
+      it('does not push events to the data layer', () => {
+        expect(dataLayer.push).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('When the app is online', () => {
+      it('purges events from offline storage', () => {
+        const events = [];
+        const dataLayer = { push: () => {} };
+        const extensions = {
+          offlineStorage: {
+            purgeEvents: jest.fn(() => Promise.resolve([])),
+            isConnected: state => state.isConnected,
+          },
+        };
+        const state = { isConnected: true };
+
+        registerEvents(events, dataLayer, state, extensions);
+        expect(extensions.offlineStorage.purgeEvents).toHaveBeenCalled();
+      });
+
+      it('pushes the new events to the data layer', () => {
+        const events = [{ event: 'some-event' }];
+        const dataLayer = { push: jest.fn() };
+        const extensions = {
+          purgeEvents: () => Promise.resolve([]),
+          isConnected: state => state.isConnected,
+        };
+        const state = { isConnected: true };
+
+        registerEvents(events, dataLayer, state, extensions);
+        expect(dataLayer.push).toHaveBeenCalledWith({ event: 'some-event' });
+      });
+
+      it('purges events from offline storage and pushes them to the data layer', () => {
+        const events = [];
+        const extensions = {
+          offlineStorage: {
+            purgeEvents: () => Promise.resolve([{ event: 'some-event' }]),
+            isConnected: state => state.isConnected,
+          },
+        };
+        const state = { isConnected: true };
+
+        // dataLayer.push will first be called with the new events.
+        // It should be called a second time with the events that were
+        // purged from offline storage.
+        let numTimesCalled = 0;
+        const dataLayer = {
+          push() {
+            numTimesCalled += 1;
+            if (numTimesCalled === 2) {
+              expect(events).toEqual({ event: 'some-event' });
+            }
+          },
+        };
+        registerEvents(events, dataLayer, state, extensions);
+      });
+    });
+  });
+
+  describe('When a logger extension is provided', () => {
+    it('calls logger.log', () => {
+      const extensions = {
+        logger: { log: jest.fn() },
       };
-      registerEvents(events, dataLayer, state, options);
+      const events = [{ event: 'some-event' }];
+      const action = { type: 'SOME_ACTION' };
+      const state = {};
+      const dataLayer = { push(){} };
+      registerEvents(events, dataLayer, state, extensions, action);
+
+      expect(extensions.logger.log).toHaveBeenCalledWith(events, action, state);
+    });
+    describe('When an offline storage extension is provided', () => {
+      describe('When the app is offline', () => {
+        it('saves the events then passes them to logger.log', () => {});
+      });
+      describe('When the app is online', () => {
+        it('calls logger.log on the new events', () => {
+          const extensions = {
+            offlineStorage: {
+              purgeEvents: () => Promise.resolve([]),
+              isConnected: state => state.isConnected,
+            },
+            logger: { log: jest.fn() },
+          };
+          const state = { isConnected: true };
+          const dataLayer = { push() {} };
+          const events = [{ event: 'some-event' }];
+          const action = { type: 'SOME_ACTION' };
+          registerEvents(events, dataLayer, state, extensions, action);
+
+          expect(extensions.logger.log).toHaveBeenCalledWith(events, action, state);
+        });
+        it('purges the offline storage and passes those events to logger.log', () => {});
+      });
     });
   });
 });


### PR DESCRIPTION
### Proposed Changes

1. Rename the `options` parameter in `createMiddleware` and `createMetaReducer` to `extensions`.
  - the objects being provided in this parameter _extend_ the functionality of ReduxGTM, they aren't really options.
2. Remove the `connectivitySelector` "option".
  - ReduxGTM will now look for an `isConnected` method in a given `offlineStorage` abstraction.
  - It does not make sense to separate the function for determining whether an app is offline or not, and the functions to save and purge events.
3. Add a `logger` extension type.
  - this will be awesome.

I'm proposing the following _expected_ shape of the extensions:

```js
{
  // extension types
  offlineStorage: {
    saveEvents(events) {}, // returns a Promise that resolves to events (for logging later)
    purgeEvents() {}, // returns a Promise
    isConnected(state) {}, // returns a connectivity boolean
  },
  customDataLayer: {
    push(event) {},
  },
  logger: {
     log(event, action, state) {},
  },
}
```

ReduxGTM will look for these extensions internally and use them accordingly.
ReduxGTM will provide constructors for different kinds of extensions.


